### PR TITLE
Fix column shifting issue in BigQuery load by enclosing string columns in quotes

### DIFF
--- a/main.py
+++ b/main.py
@@ -82,7 +82,8 @@ def main(event, context):
     print(f"Downloaded {file_name} from {bucket_name}")
 
     # Run transformation
-    run_pipeline(input_path, output_path)
+    schema_path = os.getenv("SCHEMA_PATH", "schemas/airbnb.json")
+    run_pipeline(input_path, output_path, schema_path=schema_path)
 
     # Upload to clean bucket
     clean_bucket = client.bucket(clean_bucket_name)

--- a/pipeline.py
+++ b/pipeline.py
@@ -26,6 +26,8 @@ class AirbnbCleaner:
     def clean(self):
         self.drop_duplicates()
         self.drop_nulls()
+        self.enclose_in_quotes("name")
+        self.enclose_in_quotes("host_name")
         self.clean_host_name()
         self.remove_zero_reviews()
         self.clean_quotation_marks()
@@ -43,6 +45,12 @@ class AirbnbCleaner:
         self.df.dropna(inplace=True)
         after = self.df.shape[0]
         logging.info(f"Removed nulls: {before - after} rows dropped.")
+
+    def enclose_in_quotes(self, column_name):
+        if column_name in self.df.columns:
+            self.df[column_name] = self.df[column_name].apply(
+                lambda x: f'"{x}"' if pd.notnull(x) and not str(x).startswith('"') else x)
+
 
     def clean_host_name(self):
         def clean_name(name):
@@ -93,7 +101,7 @@ def run_pipeline(input_path, output_path, schema_path=None):
         validate_columns(cleaned_df, expected_columns)
 
     # 💾 Save cleaned file
-    cleaned_df.to_csv(output_path, index=False, encoding='utf-8', quoting=csv.QUOTE_ALL)
+    cleaned_df.to_csv(output_path, index=False, quoting=csv.QUOTE_ALL, encoding='utf-8')
     print("✅ Data cleaned and saved to:", output_path)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ xlsxwriter
 google-cloud-storage
 google-cloud-bigquery
 google-api-core>=2.0.0
+

--- a/schemas/airbnb.json
+++ b/schemas/airbnb.json
@@ -1,0 +1,20 @@
+{
+  "columns": [
+    "id",
+    "name",
+    "host_id",
+    "host_name",
+    "neighbourhood_group",
+    "neighbourhood",
+    "latitude",
+    "longitude",
+    "room_type",
+    "price",
+    "minimum_nights",
+    "number_of_reviews",
+    "last_review",
+    "reviews_per_month",
+    "calculated_host_listings_count",
+    "availability_365"
+  ]
+}

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,46 @@
+import pandas as pd
+import json
+import os
+
+
+# Schema validation - checks to see if the final table in BQ matches the schema in our final CSV
+
+def load_schema(schema_path):
+    with open(schema_path, "r") as f:
+        schema = json.load(f)
+    return schema["columns"]
+
+
+def validate_columns(df, expected_columns):
+    actual_columns = list(df.columns)
+    if actual_columns != expected_columns:
+        raise ValueError(
+            f"Column mismatch detected!\n"
+            f"Expected columns ({len(expected_columns)}): {expected_columns}\n"
+            f"Actual columns ({len(actual_columns)}): {actual_columns}"
+        )
+    else:
+        print("✅ Column validation passed.")
+
+
+def remove_index_like_columns(df: pd.DataFrame) -> pd.DataFrame:
+    df = df.copy()
+    cols_to_drop = []
+
+    for col in df.columns:
+        col_clean = col.strip().lower()
+
+        # Remove index columns
+
+        if col_clean in {'index', 'row', 'unnamed: 0'}:
+            cols_to_drop.append(col)
+            continue
+
+        # Column is integer-like and looks like an auto-generated index
+
+        if pd.api.types.is_integer_dtype(df[col]) and df[col].is_monotonic_increasing:
+            if df[col].equals(pd.Series(range(df.shape[0]))) or \
+                    df[col].equals(pd.Series(range(1, df.shape[0] + 1))):
+                cols_to_drop.append(col)
+
+    return df.drop(columns=cols_to_drop)


### PR DESCRIPTION
Fix column shifting issue in BigQuery load by enclosing string columns in quotes

- Updated pipeline to wrap key string columns (e.g., 'name', 'host_name') with double quotes before saving CSV.
- Ensured consistent quoting to prevent misalignment of columns during BigQuery import.
- Resolved problem where data was pushed into wrong columns and extra 'Row' column appeared.
- Verified changes locally and via manual BigQuery load.
